### PR TITLE
Add GAM-IDF export option

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ The same input arguments are required to use the application in this format. Her
 ```bash
 python transform.py path/to/validated_coordinates.json path/to/netcdf_dir --to-csv
 python transform.py path/to/validated_coordinates.json path/to/netcdf_dir --to-netuno           # for CSV files to have only precipitation values and no header
+python transform.py path/to/validated_coordinates.json path/to/netcdf_dir --to-gam-idf        # for CSV files with annual max daily precipitation
 python transform.py path/to/validated_coordinates.json path/to/netcdf_dir --to-parquet --to-csv # to export a consolidated Parquet file and the CSVs for each city/model/scenario
 ```
 
@@ -151,6 +152,9 @@ python transform.py example/brazilian_cities_over_50k.json example/CLIMBra --to-
 
 # Or, generate precipitation data in Netuno format
 python transform.py example/brazilian_cities_over_50k.json example/CLIMBra --to-netuno
+
+# Or, generate annual maximum daily precipitation in GAM-IDF format
+python transform.py example/brazilian_cities_over_50k.json example/CLIMBra --to-gam-idf
 ```
 
 ## Tests

--- a/agents/exporters.py
+++ b/agents/exporters.py
@@ -163,6 +163,29 @@ class NetunoExporter(CSVExporter):
             include_headers=False)
 
 
+class GamIdfExporter(CSVExporter):
+    """Exports annual maximum daily precipitation in GAM-IDF format."""
+
+    def _get_file_path(self, city_name: str, model: str, scenario: str) -> Path:
+        return Path(
+            self.output_dir,
+            f"(GAM-IDF){city_name}_{model}_{scenario}").with_suffix(".csv")
+
+    def generate_csv(
+            self,
+            data_series: np.ndarray[tuple[datetime, float]],
+            city_name: str,
+            model: str,
+            scenario: str) -> None:
+        df = pd.DataFrame(data_series, columns=["date", "precipitation"])
+        df["year"] = df["date"].dt.year
+        df = df.groupby("year")["precipitation"].max().reset_index()
+        output_path = self._get_file_path(city_name, model, scenario)
+        df.to_csv(output_path, sep=";", header=False, index=False, encoding="utf-8")
+        logger.info(
+            f"Successfully exported annual max precipitation series to '{output_path.resolve()}'")
+
+
 class JSONCoordinatesExporter:
 
     @staticmethod

--- a/agents/validators.py
+++ b/agents/validators.py
@@ -146,6 +146,7 @@ class CommandLineArgsValidator:
     parquet_required: bool
     csv_required: bool
     netuno_required: bool
+    gam_idf_required: bool
     only_process_coordinates: bool
     keep_temp_files: bool
     recovery_required: bool

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -10,8 +10,13 @@ import pandas as pd
 import time_machine
 
 from agents.exporters import (
-    BasePrecipitationExporter, CSVExporter, JSONCoordinatesExporter, NetunoExporter,
-    ParquetExporter, logger)
+    BasePrecipitationExporter,
+    CSVExporter,
+    JSONCoordinatesExporter,
+    NetunoExporter,
+    ParquetExporter,
+    GamIdfExporter,
+    logger)
 from tests.samples.stub_raw_coordinates import SAMPLE_RAW_COORDINATES
 
 
@@ -168,6 +173,53 @@ class TestNetunoExporter(unittest.TestCase):
                 self.SAMPLE_DATASERIES, content.itertuples()):
             with self.subTest(index=actual_values.Index):
                 self.assertEqual(expected_values[1], actual_values[1])
+
+        self.expected_file_path.unlink()
+
+    def tearDown(self):
+        self.exporter.output_dir.rmdir()
+
+
+class TestGamIdfExporter(unittest.TestCase):
+
+    SAMPLE_DATASERIES: np.ndarray[tuple[datetime, int]] = np.array([
+        (datetime(2015, 1, 1), 20),
+        (datetime(2015, 6, 1), 30),
+        (datetime(2016, 1, 1), 50),
+        (datetime(2016, 7, 1), 15)])
+
+    def setUp(self):
+        self.exporter = GamIdfExporter(Path(__file__).parent)
+        self.expected_file_path = Path(
+            self.exporter.output_dir, "(GAM-IDF)Auridon_EC-NIRN3_SSP245_2015_2100.csv")
+        for file in self.exporter.output_dir.iterdir():
+            file.unlink()
+
+    def test_get_file_path(self):
+        file_name = self.exporter._get_file_path("Auridon", "EC-NIRN3", "SSP245_2015_2100")
+        self.assertEqual(file_name, self.expected_file_path)
+
+    def test_generate_csv(self):
+        self.exporter.generate_csv(
+            self.SAMPLE_DATASERIES, "Auridon", "EC-NIRN3", "SSP245_2015_2100")
+
+        self.assertTrue(self.expected_file_path.is_file())
+
+        self.expected_file_path.unlink()
+
+    def test_generated_csv_content(self):
+        self.exporter.generate_csv(
+            self.SAMPLE_DATASERIES, "Auridon", "EC-NIRN3", "SSP245_2015_2100")
+
+        content = pd.read_csv(
+            self.expected_file_path, header=None, names=["year", "precipitation"], sep=";")
+        expected = pd.DataFrame({"year": [2015, 2016], "precipitation": [30, 50]})
+
+        for expected_values, actual_values in zip(
+                expected.itertuples(index=False), content.itertuples(index=False)):
+            with self.subTest(year=actual_values.year):
+                self.assertEqual(expected_values.year, actual_values.year)
+                self.assertEqual(expected_values.precipitation, actual_values.precipitation)
 
         self.expected_file_path.unlink()
 

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -9,7 +9,7 @@ from zoneinfo import ZoneInfo
 
 import time_machine
 
-from agents.exporters import CSVExporter, NetunoExporter
+from agents.exporters import CSVExporter, NetunoExporter, GamIdfExporter
 from agents.validators import CommandLineArgsValidator
 from globals.constants import CLIMATE_MODELS, SSP_SCENARIOS
 from transform import (
@@ -184,10 +184,12 @@ class TestGetCSVExporter(unittest.TestCase):
     def setUp(self):
         self.args = CommandLineArgsValidator()
         self.args.input_path = Path(__file__).parent
+        self.args.gam_idf_required = False
 
     def test_get_csv_exporter_netuno_required(self):
         self.args.netuno_required = True
         self.args.csv_required = False
+        self.args.gam_idf_required = False
 
         result = get_csv_exporter(self.args)
 
@@ -197,6 +199,7 @@ class TestGetCSVExporter(unittest.TestCase):
 
     def test_get_csv_exporter_only_csv_required(self):
         self.args.netuno_required = False
+        self.args.gam_idf_required = False
         self.args.csv_required = True
 
         result = get_csv_exporter(self.args)
@@ -208,6 +211,7 @@ class TestGetCSVExporter(unittest.TestCase):
     def test_get_csv_exporter_both_required(self):
         self.args.netuno_required = True
         self.args.csv_required = True
+        self.args.gam_idf_required = True
 
         result = get_csv_exporter(self.args)
 
@@ -218,10 +222,44 @@ class TestGetCSVExporter(unittest.TestCase):
     def test_get_csv_exporter_none_required(self):
         self.args.netuno_required = False
         self.args.csv_required = False
+        self.args.gam_idf_required = False
 
         result = get_csv_exporter(self.args)
 
         self.assertIsNone(result)
+
+    def test_get_csv_exporter_gam_idf_required(self):
+        self.args.netuno_required = False
+        self.args.csv_required = False
+        self.args.gam_idf_required = True
+
+        result = get_csv_exporter(self.args)
+
+        self.assertIsInstance(result, GamIdfExporter)
+
+        result.output_dir.rmdir()
+
+    def test_get_csv_exporter_netuno_overrides_gam_idf(self):
+        self.args.netuno_required = True
+        self.args.gam_idf_required = True
+        self.args.csv_required = True
+
+        result = get_csv_exporter(self.args)
+
+        self.assertIsInstance(result, NetunoExporter)
+
+        result.output_dir.rmdir()
+
+    def test_get_csv_exporter_gam_idf_overrides_csv(self):
+        self.args.netuno_required = False
+        self.args.gam_idf_required = True
+        self.args.csv_required = True
+
+        result = get_csv_exporter(self.args)
+
+        self.assertIsInstance(result, GamIdfExporter)
+
+        result.output_dir.rmdir()
 
 
 class TestMainOperation(unittest.TestCase):
@@ -232,6 +270,7 @@ class TestMainOperation(unittest.TestCase):
         self.args.input_path = Path(__file__).parent
         self.args.csv_required = True
         self.args.netuno_required = False
+        self.args.gam_idf_required = False
         self.args.recovery_required = False
 
     def test_only_process_coordinates(self):

--- a/transform.py
+++ b/transform.py
@@ -6,7 +6,11 @@ from pathlib import Path
 from agents.calculator import CoordinatesFinder
 from agents.consolidator import Consolidator
 from agents.exporters import (
-    CSVExporter, JSONCoordinatesExporter, NetunoExporter, ParquetExporter)
+    CSVExporter,
+    JSONCoordinatesExporter,
+    NetunoExporter,
+    ParquetExporter,
+    GamIdfExporter)
 from agents.extractors import StructuredCoordinatesExtractor
 from agents.validators import CommandLineArgsValidator
 from globals.constants import CLIMATE_MODELS, SSP_SCENARIOS
@@ -118,6 +122,8 @@ def get_csv_exporter(args: CommandLineArgsValidator) -> CSVExporter | None:
     csv_exporter = None
     if args.netuno_required:
         csv_exporter = NetunoExporter(args.input_path.parent)
+    elif args.gam_idf_required:
+        csv_exporter = GamIdfExporter(args.input_path.parent)
     elif args.csv_required:
         csv_exporter = CSVExporter(args.input_path.parent)
     return csv_exporter
@@ -176,6 +182,12 @@ if __name__ == "__main__":
         help=(
             "indicates CSV files should be exported containing only precipitation data "
             "(no headers). Overrides --to-csv. Ignored if --raw-coordinates is present"))
+    parser.add_argument(
+        "-a", "--to-gam-idf", dest="gam_idf_required", action="store_true", default=False,
+        help=(
+            "indicates CSV files should be exported containing the annual maximum "
+            "daily precipitation (GAM-IDF format). Overrides --to-csv. Ignored if "
+            "--raw-coordinates is present"))
     parser.add_argument(
         "-r", "--raw-coordinates", action="store_true", dest="only_process_coordinates",
         default=False, help=(


### PR DESCRIPTION
## Summary
- introduce `GamIdfExporter` for annual max daily precipitation
- allow `--to-gam-idf` (`-a`) CLI flag
- wire new exporter through `get_csv_exporter`
- document new option in README
- update tests for new exporter and CLI

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6841a0ebeba08324aab9d24b74ca8ad1